### PR TITLE
Support both dynamic and static linking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,13 @@ let package = Package(
 	],
 	products: [
 		// Products define the executables and libraries a package produces, and make them visible to other packages.
+    .library(
+      name: "VIViewInvalidating",
+      type: .dynamic,
+      targets: ["VIViewInvalidating"]),
 		.library(
-			name: "VIViewInvalidating",
+			name: "VIViewInvalidatingStatic",
+      type: .static,
 			targets: ["VIViewInvalidating"]),
 	],
 	dependencies: [


### PR DESCRIPTION
Xcode unfortunately seems to always opt-into statically linking swift modules. However many times you'd like to instead use a module from within a Framework. Since frameworks on iOS cannot bundle modules / frameworks of their own, the only option is to use dynamic linking and bundle the module separately with the app.

This pull request adds a separate target for static linking.